### PR TITLE
Reactive test

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -9,6 +9,17 @@ er_app <- function() {
   products <- get("products")
   population <- get("population")
 
+  ui <- er_ui(products = products)
+
+  server <- purrr::partial(
+    er_server,
+    injuries = injuries, products = products, population = population
+  )
+
+  shiny::shinyApp(ui, server)
+}
+
+er_ui <- function(products) {
   prod_codes <- stats::setNames(products$prod_code, products$title)
 
   ui <- fluidPage(
@@ -28,36 +39,41 @@ er_app <- function() {
     )
   )
 
-  server <- function(input, output, session) {
-    selected <- reactive(injuries %>% dplyr::filter(.data[["prod_code"]] == input$code))
+  ui
+}
 
-    output$diag <- renderTable(
-      count_by_weight(selected(), "diag")
-    )
-    output$body_part <- renderTable(
-      count_by_weight(selected(), "body_part")
-    )
-    output$location <- renderTable(
-      count_by_weight(selected(), "location")
-    )
+er_server <- function(input,
+                      output,
+                      session,
+                      injuries,
+                      products,
+                      population) {
+  selected <- reactive(injuries %>% dplyr::filter(.data[["prod_code"]] == input$code))
 
-    summary <- reactive({
-      selected() %>%
-        dplyr::count(.data[["age"]], .data[["sex"]], wt = .data[["weight"]]) %>%
-        dplyr::left_join(population, by = c("age", "sex")) %>%
-        dplyr::mutate(rate = .data[["n"]] / .data[["population"]] * 1e4)
-    })
+  output$diag <- renderTable(
+    count_by_weight(selected(), "diag")
+  )
+  output$body_part <- renderTable(
+    count_by_weight(selected(), "body_part")
+  )
+  output$location <- renderTable(
+    count_by_weight(selected(), "location")
+  )
 
-    output$age_sex <- renderPlot(
-      {
-        summary() %>%
-          ggplot2::ggplot(ggplot2::aes(.data[["age"]], .data[["n"]], colour = .data[["sex"]])) +
-          ggplot2::geom_line() +
-          ggplot2::labs(y = "Estimated number of injuries")
-      },
-      res = 96
-    )
-  }
+  summary <- reactive({
+    selected() %>%
+      dplyr::count(.data[["age"]], .data[["sex"]], wt = .data[["weight"]]) %>%
+      dplyr::left_join(population, by = c("age", "sex")) %>%
+      dplyr::mutate(rate = .data[["n"]] / .data[["population"]] * 1e4)
+  })
 
-  shiny::shinyApp(ui, server)
+  output$age_sex <- renderPlot(
+    {
+      summary() %>%
+        ggplot2::ggplot(ggplot2::aes(.data[["age"]], .data[["n"]], colour = .data[["sex"]])) +
+        ggplot2::geom_line() +
+        ggplot2::labs(y = "Estimated number of injuries")
+    },
+    res = 96
+  )
 }

--- a/R/app.R
+++ b/R/app.R
@@ -11,8 +11,7 @@ er_app <- function() {
 
   ui <- er_ui(products = products)
 
-  server <- purrr::partial(
-    er_server,
+  server <- make_er_server(
     injuries = injuries, products = products, population = population
   )
 
@@ -42,42 +41,39 @@ er_ui <- function(products) {
   ui
 }
 
-er_server <- function(input,
-                      output,
-                      session,
-                      injuries,
-                      products,
-                      population) {
-  some_random_variable_name <- reactive(1)
+make_er_server <- function(injuries, products, population) {
+  function(input, output, session) {
+    some_random_variable_name <- reactive(1)
 
-  selected <- reactive({
-    injuries %>% dplyr::filter(.data[["prod_code"]] == input$code)
-  })
+    selected <- reactive({
+      injuries %>% dplyr::filter(.data[["prod_code"]] == input$code)
+    })
 
-  output$diag <- renderTable(
-    count_by_weight(selected(), "diag")
-  )
-  output$body_part <- renderTable(
-    count_by_weight(selected(), "body_part")
-  )
-  output$location <- renderTable(
-    count_by_weight(selected(), "location")
-  )
+    output$diag <- renderTable(
+      count_by_weight(selected(), "diag")
+    )
+    output$body_part <- renderTable(
+      count_by_weight(selected(), "body_part")
+    )
+    output$location <- renderTable(
+      count_by_weight(selected(), "location")
+    )
 
-  summary <- reactive({
-    selected() %>%
-      dplyr::count(.data[["age"]], .data[["sex"]], wt = .data[["weight"]]) %>%
-      dplyr::left_join(population, by = c("age", "sex")) %>%
-      dplyr::mutate(rate = .data[["n"]] / .data[["population"]] * 1e4)
-  })
+    summary <- reactive({
+      selected() %>%
+        dplyr::count(.data[["age"]], .data[["sex"]], wt = .data[["weight"]]) %>%
+        dplyr::left_join(population, by = c("age", "sex")) %>%
+        dplyr::mutate(rate = .data[["n"]] / .data[["population"]] * 1e4)
+    })
 
-  output$age_sex <- renderPlot(
-    {
-      summary() %>%
-        ggplot2::ggplot(ggplot2::aes(.data[["age"]], .data[["n"]], colour = .data[["sex"]])) +
-        ggplot2::geom_line() +
-        ggplot2::labs(y = "Estimated number of injuries")
-    },
-    res = 96
-  )
+    output$age_sex <- renderPlot(
+      {
+        summary() %>%
+          ggplot2::ggplot(ggplot2::aes(.data[["age"]], .data[["n"]], colour = .data[["sex"]])) +
+          ggplot2::geom_line() +
+          ggplot2::labs(y = "Estimated number of injuries")
+      },
+      res = 96
+    )
+  }
 }

--- a/R/app.R
+++ b/R/app.R
@@ -48,7 +48,11 @@ er_server <- function(input,
                       injuries,
                       products,
                       population) {
-  selected <- reactive(injuries %>% dplyr::filter(.data[["prod_code"]] == input$code))
+  some_random_variable_name <- reactive(1)
+
+  selected <- reactive({
+    injuries %>% dplyr::filter(.data[["prod_code"]] == input$code)
+  })
 
   output$diag <- renderTable(
     count_by_weight(selected(), "diag")

--- a/tests/testthat/test-er_server.R
+++ b/tests/testthat/test-er_server.R
@@ -1,0 +1,53 @@
+test_that("it updates tables when product-code changes", {
+  # define test-data
+  test_injuries <- tibble::tibble(
+    age = c(12, 51, 34, 76),
+    prod_code = c(1234, 9876, 1234, 5678),
+    diag = LETTERS[1:4],
+    sex = c("male", "female", "female", "male")
+  )
+  test_products <- tibble::tibble(
+    prod_code = c(1234, 2345, 9876, 5678),
+    title = c("toilets", "bathtubs", "tableware", "rugs")
+  )
+  test_population <- tibble::tibble(
+    age = rep(c(12, 34, 51, 76), each = 2),
+    sex = rep(c("female", "male"), times = 4),
+    population = 1
+  )
+
+  # pass test-data into the server function
+  server <- function(input, output, session) {
+    er_server(
+      input,
+      output,
+      session,
+      injuries = test_injuries,
+      products = test_products,
+      population = test_population
+    )
+  }
+
+  # check that the summary table
+  # ? should we check the values of `output$location` etc ...
+  testServer(
+    server,
+    {
+      session$setInputs(code = 2345)
+      expect_equal(
+        some_random_variable_name(),
+        1
+      )
+
+      expect_equal(
+        selected(),
+        test_injuries[integer(0), ]
+      )
+
+      expect_equal(
+        summary(),
+        expected = "BLAH"
+      )
+    }
+  )
+})

--- a/tests/testthat/test-er_server.R
+++ b/tests/testthat/test-er_server.R
@@ -17,16 +17,11 @@ test_that("it updates tables when product-code changes", {
   )
 
   # pass test-data into the server function
-  server <- function(input, output, session) {
-    er_server(
-      input,
-      output,
-      session,
-      injuries = test_injuries,
-      products = test_products,
-      population = test_population
-    )
-  }
+  server <- make_er_server(
+    injuries = test_injuries,
+    products = test_products,
+    population = test_population
+  )
 
   # check that the summary table
   # ? should we check the values of `output$location` etc ...

--- a/tests/testthat/test-er_server.R
+++ b/tests/testthat/test-er_server.R
@@ -1,3 +1,5 @@
+# TODO: test that the summary() data frame updates correctly (a bit harder than the test here)
+
 test_that("it updates tables when product-code changes", {
   # define test-data
   test_injuries <- tibble::tibble(
@@ -23,25 +25,22 @@ test_that("it updates tables when product-code changes", {
     population = test_population
   )
 
-  # check that the summary table
-  # ? should we check the values of `output$location` etc ...
+  # check that the 'selected' table updates correctly
   testServer(
     server,
     {
       session$setInputs(code = 2345)
-      expect_equal(
-        some_random_variable_name(),
-        1
-      )
 
       expect_equal(
         selected(),
         test_injuries[integer(0), ]
       )
 
+      session$setInputs(code = 1234)
+
       expect_equal(
-        summary(),
-        expected = "BLAH"
+        selected(),
+        test_injuries[c(1, 3), ]
       )
     }
   )


### PR DESCRIPTION
Add a reactivity test for the server function.
To do this, required that:
- the server function was separated from the app function
- a means to pass in datasets to the server function was available (because the test-data is likely to differ from the running-data)

Here
- `er_ui()` returns the user-interface for the app
- `make_er_server()` injects injuries, products, population into, and returns, a server function