### PR TITLE
Reactive module

### DIFF
--- a/R/app.R
+++ b/R/app.R
@@ -28,11 +28,7 @@ er_ui <- function(products) {
         selectInput("code", "Product", choices = prod_codes)
       )
     ),
-    fluidRow(
-      column(4, tableOutput("diag")),
-      column(4, tableOutput("body_part")),
-      column(4, tableOutput("location"))
-    ),
+    count_tables_ui("countTables"),
     fluidRow(
       column(12, plotOutput("age_sex"))
     )
@@ -47,15 +43,7 @@ make_er_server <- function(injuries, products, population) {
       injuries %>% dplyr::filter(.data[["prod_code"]] == input$code)
     })
 
-    output$diag <- renderTable(
-      count_by_weight(selected(), "diag")
-    )
-    output$body_part <- renderTable(
-      count_by_weight(selected(), "body_part")
-    )
-    output$location <- renderTable(
-      count_by_weight(selected(), "location")
-    )
+    count_tables_server("countTables", selected = selected)
 
     summary <- reactive({
       selected() %>%

--- a/R/mod-count_tables.R
+++ b/R/mod-count_tables.R
@@ -1,0 +1,24 @@
+count_tables_ui <- function(id) {
+  ns <- NS(id)
+  fluidRow(
+    column(4, tableOutput(ns("diag"))),
+    column(4, tableOutput(ns("body_part"))),
+    column(4, tableOutput(ns("location")))
+  )
+}
+
+count_tables_server <- function(id, selected) {
+  stopifnot(is.reactive(selected))
+
+  moduleServer(id, function(input, output, session) {
+    output$diag <- renderTable(
+      count_by_weight(selected(), "diag")
+    )
+    output$body_part <- renderTable(
+      count_by_weight(selected(), "body_part")
+    )
+    output$location <- renderTable(
+      count_by_weight(selected(), "location")
+    )
+  })
+}

--- a/R/mod-count_tables.R
+++ b/R/mod-count_tables.R
@@ -11,14 +11,19 @@ count_tables_server <- function(id, selected) {
   stopifnot(is.reactive(selected))
 
   moduleServer(id, function(input, output, session) {
-    output$diag <- renderTable(
+    diag <- reactive(
       count_by_weight(selected(), "diag")
     )
-    output$body_part <- renderTable(
+    output$diag <- renderTable(diag())
+
+    body_part <- reactive(
       count_by_weight(selected(), "body_part")
     )
-    output$location <- renderTable(
+    output$body_part <- renderTable(body_part())
+
+    location <- reactive(
       count_by_weight(selected(), "location")
     )
+    output$location <- renderTable(location())
   })
 }

--- a/tests/testthat/test-mod-count_tables.R
+++ b/tests/testthat/test-mod-count_tables.R
@@ -1,0 +1,43 @@
+test_selected <- tibble::tibble(
+  age = c(12, 34),
+  prod_code = 1234,
+  diag = c("A", "C"),
+  body_part = c("leg", "leg"),
+  location = c("Home", "Other Public Property"),
+  sex = c("male", "female"),
+  weight = c(20, 15)
+)
+
+expected_diag <- tibble::tibble(
+  diag = c("A", "C"),
+  n = c(20, 15)
+)
+expected_body_part <- tibble::tibble(
+  body_part = "leg",
+  n = 35
+)
+expected_location <- tibble::tibble(
+  location = c("Home", "Other Public Property"),
+  n = c(20, 15)
+)
+
+test_that("tables display the counts correctly", {
+  rx_selected <- reactive(test_selected)
+
+  testServer(count_tables_server, args = list(selected = rx_selected), {
+    expect_equal(
+      diag(),
+      expected = expected_diag
+    )
+
+    expect_equal(
+      body_part(),
+      expected = expected_body_part
+    )
+
+    expect_equal(
+      location(),
+      expected = expected_location
+    )
+  })
+})


### PR DESCRIPTION
Using testServer to test a module.
To do this:
- Separated a module out of the main ER-injuries app.
- Separated computation from rendering of a table, so the computed table could be used in tests